### PR TITLE
agent: Do not block goroutine when metrics endpoint is disabled

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1875,13 +1875,12 @@ func runDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *daem
 
 	d.startStatusCollector(cleaner)
 
-	go func(errs <-chan error) {
-		err := <-errs
-		if err != nil {
+	go func() {
+		if err := initMetrics(); err != nil {
 			log.WithError(err).Error("Cannot start metrics server")
 			params.Shutdowner.Shutdown(hive.ShutdownWithError(err))
 		}
-	}(initMetrics())
+	}()
 
 	d.startAgentHealthHTTPService()
 	if option.Config.KubeProxyReplacementHealthzBindAddr != "" {

--- a/daemon/cmd/metrics.go
+++ b/daemon/cmd/metrics.go
@@ -36,15 +36,13 @@ func (h *getMetrics) Handle(params restapi.GetMetricsParams) middleware.Responde
 	return restapi.NewGetMetricsOK().WithPayload(metrics)
 }
 
-func initMetrics() <-chan error {
-	var errs <-chan error
-
+func initMetrics() error {
 	if option.Config.PrometheusServeAddr != "" {
 		log.Infof("Serving prometheus metrics on %s", option.Config.PrometheusServeAddr)
-		errs = metrics.Enable(option.Config.PrometheusServeAddr)
+		return metrics.Enable(option.Config.PrometheusServeAddr)
 	}
 
-	return errs
+	return nil
 }
 
 type bootstrapStatistics struct {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1608,22 +1608,16 @@ func Unregister(c prometheus.Collector) bool {
 
 // Enable begins serving prometheus metrics on the address passed in. Addresses
 // of the form ":8080" will bind the port on all interfaces.
-func Enable(addr string) <-chan error {
-	errs := make(chan error, 1)
-
-	go func() {
-		// The Handler function provides a default handler to expose metrics
-		// via an HTTP server. "/metrics" is the usual endpoint for that.
-		mux := http.NewServeMux()
-		mux.Handle("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
-		srv := http.Server{
-			Addr:    addr,
-			Handler: mux,
-		}
-		errs <- srv.ListenAndServe()
-	}()
-
-	return errs
+func Enable(addr string) error {
+	// The Handler function provides a default handler to expose metrics
+	// via an HTTP server. "/metrics" is the usual endpoint for that.
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
+	srv := http.Server{
+		Addr:    addr,
+		Handler: mux,
+	}
+	return srv.ListenAndServe()
 }
 
 // GetCounterValue returns the current value


### PR DESCRIPTION
When `prometheus-serve-addr` is set to an empty string to disable serving metrics for the agent, `initMetrics` returns a `nil` channel, causing the goroutine spawned in [daemon_main.go:L1878](https://github.com/cilium/cilium/blob/175b2f1c878cd7b827c33decd29275e10a2b6dde/daemon/cmd/daemon_main.go#L1878) to block indefinitely on a channel receive operation because a receive on a `nil` channel blocks forever.

This can be confirmed by enabling profiling and looking at the full goroutine stack trace available at `/debug/pprof/goroutine?debug=2`.

Relevant excerpts from the goroutine stack trace:
```
goroutine 1051 [chan receive (nil chan), 462 minutes]:
github.com/cilium/cilium/daemon/cmd.runDaemon.func4(0xc000571f98?)
	/go/src/github.com/cilium/cilium/daemon/cmd/daemon_main.go:1847 +0x3e
created by github.com/cilium/cilium/daemon/cmd.runDaemon
	/go/src/github.com/cilium/cilium/daemon/cmd/daemon_main.go:1846 +0xbbb
```

This changelist fixes this behaviour by returning an error directly, instead of a `chan error`. It also removes spawning an additional goroutine in `metrics.Enable`, as `initMetrics` already runs in a separate goroutine and it's more idiomatic to let the caller decide whether an operation needs to be run concurrently.